### PR TITLE
cm: config: Select the appropriate default alarm tone

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -66,7 +66,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Default notification/alarm sounds
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Helium.ogg
+    ro.config.alarm_alert=Hassium.ogg
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 # Thank you, please drive thru!


### PR DESCRIPTION
In Nougat, CAF removed Helium as it is a duplicate of Hassium.
Switch back to choosing Hassium as the default alarm tone.

This essentially reverts commit 2b999181c8a7963b81a419366be2e022717f0601.

Change-Id: I62ff1565c76fddf2f744c26c44f30e940cf25b7b