### PR TITLE
Add LTE support for China Telecom Macau.

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -3090,6 +3090,8 @@
   <apn carrier="Hutchison Macau" mcc="455" mnc="03" apn="web-g.three.com.hk" user="hutchison" password="1234" type="default,supl" />
   <apn carrier="CTM" mcc="455" mnc="04" apn="ctm-mobile" proxy="192.168.99.2" port="8080" type="default,supl" />
   <apn carrier="CTM MMS" mcc="455" mnc="04" apn="ctmmms" mmsc="http://mms.wap.ctm.net:8002" mmsproxy="192.168.99.3" mmsport="8080" type="mms" />
+  <apn carrier="澳門電信LTE" mcc="455" mnc="07" apn="ctlte" user="" password="" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="澳門電信NET" mcc="455" mnc="07" apn="ctnet" user="" password="" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Mobitel KH" mcc="456" mnc="01" apn="postpaid" user="mobitel" password="mobitel" type="default,supl" />
   <apn carrier="Mobitel Cellcard" mcc="456" mnc="01" apn="cellcard" user="mobitel" password="mobitel" type="default,supl" />
   <apn carrier="Mobitel MMS" mcc="456" mnc="01" apn="mms" user="mobitel" password="mobitel" mmsc="http://mms.mobitel.com.kh/mmsc" mmsproxy="203.144.95.98" mmsport="3130" type="mms" />


### PR DESCRIPTION
Notice: I am very likely the only one here having a Macau SIM card, so I am the only one who can confirm this change.
Please do not paste APN settings copied from other vendors or devices. 
The exactly APN used in MIUI is not MMC455/MNC07 but MMC455/MNC02, maybe Xiaomi has done extra calculations to do so.

It is a waste of time to argue which APN is “BETTER”. This one works for China Telecom Macau LTE. I can confirm this. If you live out of Macau, you can't.
Screenshot: https://pics.mustu.cn/assets/52c546f9-e883-4335-a090-c9e66ec1c77e.png

CTWAP and CTNET are not discussed in this change.
CTNET is for 3G. There are still someone using 3G. You can add one if you are interested in this, or I will add one if I have a confirmed APN settings from China Telecom Macau staffs.
CTWAP is outdated. If you use CTWAP in China, most apps will tell you "CTWAP is deprecated, use CTNET instead.".

China is moving from 3G to 4G/LTE, and will soon be moving from 4G to 5G. If you live out of China, please simply +1 and merge it. If you live in China and having problem with this APN, we can discuss this with beer and snacks.

For now, there is NO APN settings for MMC455/MNC07, so this APN won't harm anyone else living out of Macau.

Merge this change, that's it.


Update:
Add CTNET for MMC455/MNC07
Screenshot: https://pics.mustu.cn/assets/bbd9e8ee-7af5-4d5e-af6d-3722de329ef0.png

Change-Id: I8600dbbb8d3ea567f04a516d7a296dbaaebc5216