### PR TITLE
Fix extract_utils when not using blob sections

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -796,7 +796,11 @@ function extract() {
         exit 1
     fi
 
-    parse_file_list "$1" "$3"
+    if [ -z "$3" ]; then
+        parse_file_list "$1"
+    else
+        parse_file_list "$1" "$3"
+    fi
 
     # Allow failing, so we can try $DEST and/or $FILE
     set +e


### PR DESCRIPTION
"$3" evaluates as "" when $3 is empty, and so $# is still 3
When $3 is empty, do not use it

Change-Id: I87df7dd8ed23cac3d4cff16dce0996bbe0a3e6cc