### PR TITLE
templates: Default to sanitize vendor folder during extraction

### DIFF
--- a/build/templates/extract-files.sh
+++ b/build/templates/extract-files.sh
@@ -34,8 +34,8 @@ if [ ! -f "$HELPER" ]; then
 fi
 . "$HELPER"
 
-# default to not sanitizing the vendor folder before extraction
-clean_vendor=false
+# Default to sanitizing the vendor folder before extraction
+CLEAN_VENDOR=true
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -44,9 +44,9 @@ while [ "$1" != "" ]; do
                                 ;;
         -s | --section )        shift
                                 SECTION=$1
-                                clean_vendor=false
+                                CLEAN_VENDOR=false
                                 ;;
-        -c | --clean-vendor )   clean_vendor=true
+        -n | --no-cleanup )     CLEAN_VENDOR=false
                                 ;;
     esac
     shift
@@ -57,7 +57,7 @@ if [ -z "$SRC" ]; then
 fi
 
 # Initialize the helper
-setup_vendor "$DEVICE" "$VENDOR" "$CM_ROOT" false $clean_vendor
+setup_vendor "$DEVICE" "$VENDOR" "$CM_ROOT" false "$CLEAN_VENDOR"
 
 extract "$MY_DIR"/proprietary-files.txt "$SRC" "$SECTION"
 


### PR DESCRIPTION
 * This was always the default behaviour and doesn't require
   any additional argument in order to make use of pinning feature
   (pinned blobs are only considered when vendor folder is removed)

Change-Id: I34ff7678bd6800a2c593e9fe128cc151c59967da