### PR TITLE
envsetup: Fix installboot on ZSH

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -322,12 +322,15 @@ function installboot()
     if (adb shell getprop ro.cm.device | grep -q "$CM_BUILD");
     then
         adb push $OUT/boot.img /cache/
-        for i in $OUT/system/lib/modules/*;
-        do
-            adb push $i /system/lib/modules/
-        done
+        if [ -e "$OUT/system/lib/modules/*" ];
+        then
+            for i in $OUT/system/lib/modules/*;
+            do
+                adb push $i /system/lib/modules/
+            done
+            adb shell chmod 644 /system/lib/modules/*
+        fi
         adb shell dd if=/cache/boot.img of=$PARTITION
-        adb shell chmod 644 /system/lib/modules/*
         echo "Installation complete."
     else
         echo "The connected device does not appear to be $CM_BUILD, run away!"


### PR DESCRIPTION
* ZSH errors out when it doesn't find anything in $OUT/system/lib/modules/.
* So add a check to avoid error while using installboot() with a target
  that doesn't have modules enabled.

Change-Id: Ibe66f6962943e9b90c7059a4c9b4ded558318326